### PR TITLE
CVSB-17157 - retry up to X times on error

### DIFF
--- a/src/functions/atfGenInit.ts
+++ b/src/functions/atfGenInit.ts
@@ -12,7 +12,7 @@ import {StreamService} from "../services/StreamService";
  * @param context - λ Context
  * @param callback - callback function
  */
-const atfGenInit: Handler = async (event: SQSEvent, context?: Context, callback?: Callback): Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
+const atfGenInit: Handler = async (event: SQSEvent, context?: Context, callback?: Callback): Promise<void | Array<PromiseResult<SendMessageResult, AWSError>>> => {
     if (!event) {
         console.error("ERROR: event is not defined.");
         return;
@@ -27,14 +27,17 @@ const atfGenInit: Handler = async (event: SQSEvent, context?: Context, callback?
 
     // Add each visit record to the queue
     records.forEach(async (record: DynamoDBRecord) => {
-            sendMessagePromises.push(sqService.sendMessage(JSON.stringify(record)));
+        sendMessagePromises.push(sqService.sendMessage(JSON.stringify(record)));
     });
 
     return Promise.all(sendMessagePromises)
-    .catch((error: AWSError) => {
-        console.error(error);
-        throw error;
-    });
+        .catch((error: AWSError) => {
+            console.error(error);
+            console.log("records");
+            console.log(records);
+            // Lambda will retry up to X times or until the message expires, after which the message will be sent to the dlq.
+            throw error;
+        });
 };
 
 export {atfGenInit};

--- a/tests/unit/atfGenInitFunction.unitTest.ts
+++ b/tests/unit/atfGenInitFunction.unitTest.ts
@@ -9,6 +9,15 @@ describe("retroGenInit  Function",  () => {
     jest.restoreAllMocks();
     jest.resetModuleRegistry();
   });
+
+  describe("if the event is undefined", () => {
+    it("should return undefined", async () => {
+      expect.assertions(1);
+      const result = await atfGenInit(undefined, ctx, () => { return; });
+      expect(result).toBe(undefined);
+    });
+  });
+
   describe("with good event", () => {
     it("should invoke SQS service with correct params", async () => {
       const sendMessage = jest.fn().mockResolvedValue("Success");


### PR DESCRIPTION
This ticket covers the work required to fix EDH marshaller lambda which sometimes fails when the payload is too big (It returns 413 errors)

If the lambda fails to process the message and throws an error, then it will log the error and it will retry up to X times (configurable from AWS, currently set to 3 times) or until the message expires (60 seconds), after which it will send the message to the respective DLQs for further investigation.

https://jira.dvsacloud.uk/browse/CVSB-17157