### PR TITLE
VTA-292: Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1392,9 +1392,9 @@
       "dev": true
     },
     "@serverless/cli": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.5.2.tgz",
-      "integrity": "sha512-FMACx0qPD6Uj8U+7jDmAxEe1tdF9DsuY5VsG45nvZ3olC9xYJe/PMwxWsjXfK3tg1HUNywYAGCsy7p5fdXhNzw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.6.0.tgz",
+      "integrity": "sha512-1Muw/KhS4sZ6+ZrXBdmVY9zAwZh03lF7v1DKtaZ0cmxjqQBwPLoO40rOGXlxR97pyufe2NS6rD/p+ri8NGqeXg==",
       "dev": true,
       "requires": {
         "@serverless/core": "^1.1.2",
@@ -1407,7 +1407,7 @@
         "figures": "^3.2.0",
         "minimist": "^1.2.5",
         "prettyoutput": "^1.2.0",
-        "strip-ansi": "^5.2.0"
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "@serverless/utils": {
@@ -1425,9 +1425,9 @@
           }
         },
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "dotenv": {
@@ -1437,12 +1437,12 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "uuid": {
@@ -1676,53 +1676,6 @@
         }
       }
     },
-    "@serverless/platform-client-china": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.1.13.tgz",
-      "integrity": "sha512-kQuWjHiBeslZ1SkIFzXRoEi+CCunUEBOyJRU7Zeg5l4vV4U63G8Ax1waMXxoBILgYK5cDG0F/y+UoSAvEhJmZw==",
-      "dev": true,
-      "requires": {
-        "@serverless/utils-china": "^1.0.14",
-        "adm-zip": "^0.5.1",
-        "archiver": "^5.0.2",
-        "axios": "^0.21.1",
-        "dotenv": "^8.2.0",
-        "fast-glob": "^3.2.4",
-        "fs-extra": "^9.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "js-yaml": "^3.14.0",
-        "minimatch": "^3.0.4",
-        "querystring": "^0.2.0",
-        "run-parallel-limit": "^1.0.6",
-        "traverse": "^0.6.6",
-        "urlencode": "^1.1.0",
-        "ws": "^7.3.1"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
-        }
-      }
-    },
     "@serverless/template": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@serverless/template/-/template-1.1.4.tgz",
@@ -1881,54 +1834,6 @@
         }
       }
     },
-    "@serverless/utils-china": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.1.0.tgz",
-      "integrity": "sha512-4iul4BaS6wi8c4fhRahkxt8IDSGB9swVyK3SpVqP4LJNGJ5UtKvStxa6pMC4OMVWs0LDCaLGlfFqOgBUo3VxRQ==",
-      "dev": true,
-      "requires": {
-        "@tencent-sdk/capi": "^1.1.8",
-        "dijkstrajs": "^1.0.1",
-        "dot-qs": "0.2.0",
-        "duplexify": "^4.1.1",
-        "end-of-stream": "^1.4.4",
-        "got": "^11.8.2",
-        "https-proxy-agent": "^5.0.0",
-        "kafka-node": "^5.0.0",
-        "protobufjs": "^6.9.0",
-        "qrcode-terminal": "^0.12.0",
-        "socket.io-client": "^2.3.0",
-        "winston": "3.2.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "winston": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
-          "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.1",
-            "diagnostics": "^1.1.1",
-            "is-stream": "^1.1.0",
-            "logform": "^2.1.1",
-            "one-time": "0.0.4",
-            "readable-stream": "^3.1.1",
-            "stack-trace": "0.0.x",
-            "triple-beam": "^1.3.0",
-            "winston-transport": "^4.3.0"
-          }
-        }
-      }
-    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1975,61 +1880,6 @@
             "stealthy-require": "^1.1.1",
             "tough-cookie": "^2.3.3"
           }
-        }
-      }
-    },
-    "@tencent-sdk/cls": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@tencent-sdk/cls/-/cls-0.2.1.tgz",
-      "integrity": "sha512-nSEPLAQyXf694XqoXi/OnWjfaJNPoo+JaPt81Kpy1QogOSZdEqEebgGj/ROs8kPjRa3kf+6+0s8MSQRtJBOOyQ==",
-      "dev": true,
-      "requires": {
-        "got": "^11.8.0"
-      }
-    },
-    "@tencent-sdk/common": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@tencent-sdk/common/-/common-0.1.0.tgz",
-      "integrity": "sha512-WHVGulaFv/CLwSqYC5501FCMNclu7B7nH1OminksjV2HSonIvx3o3Pms4+2/2Lse/sB5RCmPiiitV7g09b4mWw==",
-      "dev": true,
-      "requires": {
-        "@tencent-sdk/capi": "^1.1.8",
-        "camelcase": "^6.2.0",
-        "type-fest": "^1.0.2"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.0.tgz",
-          "integrity": "sha512-++0N6KyAj0t2webXst0PE0xuXb4Dv3z1Z+4SGzK+j/epeWBZCfkQbkW/ezscZwpinmBQ5wu/l4TqagKSVcAGCA==",
-          "dev": true
-        }
-      }
-    },
-    "@tencent-sdk/faas": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@tencent-sdk/faas/-/faas-0.1.5.tgz",
-      "integrity": "sha512-6wEkJCm1rN9LOgH/BZHW6ajJpYZQuf1qwfW+tGTNkczW0RepWASznS6MCzWC9HX09oosVpg8sGCGtcgWQSP1Qg==",
-      "dev": true,
-      "requires": {
-        "@tencent-sdk/capi": "^1.1.8",
-        "@tencent-sdk/cls": "0.2.1",
-        "@tencent-sdk/common": "0.1.0",
-        "camelcase": "^6.2.0",
-        "dayjs": "^1.10.4"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-          "dev": true
         }
       }
     },
@@ -2724,13 +2574,30 @@
       }
     },
     "aws-lambda": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-0.1.2.tgz",
-      "integrity": "sha1-GbFYUHXfMWeVl7l2pfHe9h8SzO4=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
       "requires": {
-        "aws-sdk": "^*",
-        "commander": "^2.5.0",
-        "dotenv": "^0.4.0"
+        "aws-sdk": "^2.814.0",
+        "commander": "^3.0.2",
+        "js-yaml": "^3.14.1",
+        "watchpack": "^2.0.0-beta.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "aws-lambda-mock-context": {
@@ -2745,19 +2612,26 @@
       }
     },
     "aws-sdk": {
-      "version": "2.562.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.562.0.tgz",
-      "integrity": "sha512-Uvt7qUXufjSxWMMfTs62xulGY7wnRut3y3daDtHSUdY62BnGjZGpp0dq/RW/bNi3aAjogEZNjWNZkLdtkHFeiQ==",
+      "version": "2.1066.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1066.0.tgz",
+      "integrity": "sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==",
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "jmespath": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+          "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+        }
       }
     },
     "aws-sign2": {
@@ -2815,12 +2689,12 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "babel-code-frame": {
@@ -3285,9 +3159,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -3805,7 +3679,8 @@
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
     },
     "compare-func": {
       "version": "2.0.0",
@@ -4506,11 +4381,6 @@
       "resolved": "https://registry.npmjs.org/dot-qs/-/dot-qs-0.2.0.tgz",
       "integrity": "sha1-02UX/iS3zaYfznpQJqACSvr1pDk=",
       "dev": true
-    },
-    "dotenv": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-0.4.0.tgz",
-      "integrity": "sha1-9vs1E2PC2SIHJFxzeALJq1rhSVo="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -5392,9 +5262,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true
     },
     "for-in": {
@@ -5665,6 +5535,11 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -6355,9 +6230,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -7935,7 +7810,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -8059,12 +7935,6 @@
         }
       }
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8102,15 +7972,23 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+          "dev": true
+        }
       }
     },
     "jszip": {
@@ -9127,10 +9005,37 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -10530,20 +10435,20 @@
       },
       "dependencies": {
         "@serverless/components": {
-          "version": "3.11.0",
-          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.11.0.tgz",
-          "integrity": "sha512-TGQJvBqL6dyKNjZ3u1P+1MXEABH5bAUkSHXQgQsiiaKgu+3+Kvd6eHnDMd9eNghENEFA33HR5zFeCyEFvlxHeA==",
+          "version": "3.18.2",
+          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.18.2.tgz",
+          "integrity": "sha512-jQSgd3unajU94R6vjzD0l+PS5lVcky0vrE1DOfb28VPgmaS48+I/niavWR7+SOt0mYjIkUlwBI73a2ZuqeYK6Q==",
           "dev": true,
           "requires": {
             "@serverless/platform-client": "^4.2.2",
-            "@serverless/platform-client-china": "^2.1.9",
+            "@serverless/platform-client-china": "^2.2.0",
             "@serverless/utils": "^4.0.0",
-            "@tencent-sdk/faas": "^0.1.4",
             "adm-zip": "^0.5.4",
             "ansi-escapes": "^4.3.1",
             "chalk": "^4.1.0",
             "child-process-ext": "^2.1.1",
             "chokidar": "^3.5.1",
+            "ci-info": "^3.2.0",
             "dayjs": "^1.10.4",
             "dotenv": "^8.2.0",
             "fastest-levenshtein": "^1.0.12",
@@ -10566,6 +10471,29 @@
             "uuid": "^8.3.2"
           },
           "dependencies": {
+            "@serverless/platform-client-china": {
+              "version": "2.3.4",
+              "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.3.4.tgz",
+              "integrity": "sha512-JRrI3gnUZ0e6on8hHtVr4CwnhrU0jXd3iVfJknEE9tLS//syV77h7PhalZ79SemrboykRoSqhdu9qHf/wiFJ3A==",
+              "dev": true,
+              "requires": {
+                "@serverless/utils-china": "^1.1.4",
+                "adm-zip": "^0.5.1",
+                "archiver": "^5.0.2",
+                "axios": "^0.21.1",
+                "dotenv": "^8.2.0",
+                "fast-glob": "^3.2.4",
+                "fs-extra": "^9.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "js-yaml": "^3.14.0",
+                "minimatch": "^3.0.4",
+                "querystring": "^0.2.0",
+                "run-parallel-limit": "^1.0.6",
+                "traverse": "^0.6.6",
+                "urlencode": "^1.1.0",
+                "ws": "^7.3.1"
+              }
+            },
             "@serverless/utils": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-4.1.0.tgz",
@@ -10584,6 +10512,12 @@
                 "write-file-atomic": "^3.0.3"
               },
               "dependencies": {
+                "argparse": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                  "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                  "dev": true
+                },
                 "js-yaml": {
                   "version": "4.1.0",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -10593,6 +10527,15 @@
                     "argparse": "^2.0.1"
                   }
                 }
+              }
+            },
+            "argparse": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+              "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
               }
             },
             "dotenv": {
@@ -10609,19 +10552,28 @@
               "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
-              },
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.10",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-                  "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-                  "dev": true,
-                  "requires": {
-                    "sprintf-js": "~1.0.2"
-                  }
-                }
               }
             }
+          }
+        },
+        "@serverless/utils-china": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.1.5.tgz",
+          "integrity": "sha512-pykhxsI+TlEbZzDUq5dkJPVWceNpaLU2ILEMsjUwyqGPsSE/g8Lrf7AhXseKtNK/7le3lduNnPacmY4Jb+GT+g==",
+          "dev": true,
+          "requires": {
+            "@tencent-sdk/capi": "^1.1.8",
+            "dijkstrajs": "^1.0.1",
+            "dot-qs": "0.2.0",
+            "duplexify": "^4.1.1",
+            "end-of-stream": "^1.4.4",
+            "got": "^11.8.2",
+            "https-proxy-agent": "^5.0.0",
+            "kafka-node": "^5.0.0",
+            "protobufjs": "^6.9.0",
+            "qrcode-terminal": "^0.12.0",
+            "socket.io-client": "^2.3.0",
+            "winston": "3.2.1"
           }
         },
         "ajv": {
@@ -10637,9 +10589,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -10656,6 +10608,15 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
         },
         "aws-sdk": {
           "version": "2.923.0",
@@ -10786,9 +10747,9 @@
           "dev": true
         },
         "ramda": {
-          "version": "0.27.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-          "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+          "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
           "dev": true
         },
         "semver": {
@@ -10801,12 +10762,12 @@
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -10819,9 +10780,9 @@
           }
         },
         "tar": {
-          "version": "6.1.5",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.5.tgz",
-          "integrity": "sha512-FiK6MQyyaqd5vHuUjbg/NpO8BuEGeSXcmlH7Pt/JkugWS8s0w8nKybWjHDJiwzCAIKZ66uof4ghm4tBADjcqRA==",
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -10838,6 +10799,23 @@
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "dev": true
         },
+        "winston": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+          "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.1",
+            "diagnostics": "^1.1.1",
+            "is-stream": "^1.1.0",
+            "logform": "^2.1.1",
+            "one-time": "0.0.4",
+            "readable-stream": "^3.1.1",
+            "stack-trace": "0.0.x",
+            "triple-beam": "^1.3.0",
+            "winston-transport": "^4.3.0"
+          }
+        },
         "write-file-atomic": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -10849,6 +10827,12 @@
             "signal-exit": "^3.0.2",
             "typedarray-to-buffer": "^3.1.5"
           }
+        },
+        "ws": {
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+          "dev": true
         }
       }
     },
@@ -12267,9 +12251,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-array": {
@@ -12408,9 +12392,9 @@
       "dev": true
     },
     "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
+      "integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
       "dev": true
     },
     "trim-repeated": {
@@ -12795,6 +12779,15 @@
         "makeerror": "1.0.x"
       }
     },
+    "watchpack": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+      "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      }
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -12850,43 +12843,13 @@
       "optional": true
     },
     "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "tslint src/**/*.ts tests/**/*.ts",
     "format": "prettier --write .",
     "sonar-scanner": "sonar-scanner",
-    "audit": "npm audit",
+    "audit": "npm audit --prod",
     "package": "mkdir ${ZIP_NAME} && cp package.json package-lock.json ${ZIP_NAME}/ && cp -r .build/src/* ${ZIP_NAME}/ && cd ${ZIP_NAME} && npm ci --production && rm package.json package-lock.json && zip -qr ../${ZIP_NAME}.zip .",
     "tools-setup": "echo 'nothing to do'"
   },
@@ -48,8 +48,8 @@
     "instrument": true
   },
   "dependencies": {
-    "aws-lambda": "^0.1.2",
-    "aws-sdk": "^2.562.0",
+    "aws-lambda": "^1.0.7",
+    "aws-sdk": "^2.1066.0",
     "aws-xray-sdk": "^2.3.3",
     "node-yaml": "^3.2.0",
     "reflect-metadata": "^0.1.13"


### PR DESCRIPTION
## VTA-292: Update dependencies

Updated dependencies as per npm audit recommendations, added --prod flag to audit script.
[VTA-292](https://jira.dvsacloud.uk/browse/VTA-292)

## Checklist

- [X] Branch is rebased against the latest develop
- [X] PR title includes the JIRA ticket number
- [X] Squashed commits contain the JIRA ticket number
- [X] Link to the PR added to the repo
